### PR TITLE
Remove confusing Gratipay references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 #Contributing to Web App Firewall
 
 ##What is "open work"?
-At http://gratipay.com/about, we have a definition:
+At http://gratipay.com/about, they have a definition:
 
 > “Open work” means that your company or organization makes it easy for any individual to do your work for you without asking you first, and as a result to share in any revenue you generate. 
 
@@ -11,22 +11,17 @@ Do work first, ask permission later. Fun, isn't it? If you are opening a new iss
 ##How you can contribute
 Whether you are a programmer or not, you can contribute to Web App Firewall. Below are some ideas we've modified from [this great blog post](http://blog.smartbear.com/programming/14-ways-to-contribute-to-open-source-without-being-a-programming-genius-or-a-rock-star/) (more details at the link). You can check out a similar list [here](http://24pullrequests.com/contributing). If you see anything below that doesn't make sense, _relax_--find something you understand and start from there.
 
-1. Follow along on GitHub. Looks like you're in the right place already! See all project repositories at http://github.com/gratipay.
-2. Follow the [Gratipay blog](https://medium.com/gratipay-blog)
-3. Diagnose a bug by creating an issue
-3. Suggest an improvement by creating an issue
-4. Close resolved issues ([here's the big list](https://github.com/shaman33/web_app_firewall/issues))
-5. [Test the code](https://github.com/shaman33/web_app_firewall/blob/master/README.md)
-6. Fix a bug/resolve an issue
-7. Write a test
-8. Add a comment to the code
-11. Create an example
-12. Answer a question
-13. Write a blog post
-14. Improve the website (either [gratipay.com](http://gratipay.com) or [http://inside.gratipay.com](inside.gratipay.com))
-
-###More info
-If you want to really get involved, then check out our full documentation for contributors: http://inside.gratipay.com/
+1. Follow along on GitHub. Looks like you're in the right place already! See the project repository at https://github.com/shaman33/web_app_firewall.
+1. Diagnose a bug by creating an issue
+1. Suggest an improvement by creating an issue
+1. Close resolved issues ([here's the big list](https://github.com/shaman33/web_app_firewall/issues))
+1. [Test the code](https://github.com/shaman33/web_app_firewall/blob/master/README.md)
+1. Fix a bug/resolve an issue
+1. Write a test
+1. Add a comment to the code
+1. Create an example
+1. Answer a question
+1. Write a blog post
 
 ##License
 Web App Firewall is [licensed under CC0](https://github.com/shaman33/web_app_firewall/blob/master/COPYING).


### PR DESCRIPTION
This makes the text less confusing for potential contributors.

To finish up https://github.com/gratipay/team-review/issues/264 so we can approve.